### PR TITLE
Change copyright to MPG & NYU

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, Open Dynamic Robot Initiative
+Copyright (c) 2019, Max Planck Gesellschaft, New York University
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Like on the other repos, change the name of the copyright holders from "Open Dynamic Robot Initiative" to MPG & NYU.